### PR TITLE
修复数字精度 Bug

### DIFF
--- a/src/magic.js
+++ b/src/magic.js
@@ -126,7 +126,12 @@ function MagicJS(scriptName = "MagicJS", logLevel = "INFO") {
       }
       if (typeof val === "undefined") val = null;
       try {
-        if (!!val && typeof val === "string") val = JSON.parse(val);
+        if (!!val && typeof val === "string"){
+          var obj = JSON.parse(val);
+          if(typeof obj == 'object' && obj ){
+            val = obj;
+          }
+        }
       } catch (err) {}
       this.logDebug(`READ DATA [${key}]${!!session ? `[${session}]` : ""}(${typeof val})\n${JSON.stringify(val)}`);
       return val;


### PR DESCRIPTION
bug修复，如果写入的数据为长数字，则读取后使用JSON.parse 会丢失精度。
用例值：1553601695173312512
写入 1553601695173312512，读取正常，经JSON.parse之后，变成 1553601695173312500