### PR TITLE
优化脚本对自动补全User-Agent的兼容性

### DIFF
--- a/src/magic.js
+++ b/src/magic.js
@@ -356,7 +356,7 @@ function MagicJS(scriptName = "MagicJS", logLevel = "INFO") {
       }
 
       // 自动补完User-Agent，减少请求特征
-      if (!!!_options.headers || typeof _options.headers !== "object" || !!!_options.headers["User-Agent"]) {
+      if (!!!_options.headers || typeof _options.headers !== "object" || !!!_options.headers["User-Agent"] || !!!_options.headers["user-agent"]) {
         if (!!!_options.headers || typeof _options.headers !== "object") _options.headers = {};
         if (this.isNode) _options.headers["User-Agent"] = this.pcUserAgent;
         else _options.headers["User-Agent"] = this.iOSUserAgent;

--- a/src/magic.js
+++ b/src/magic.js
@@ -356,7 +356,7 @@ function MagicJS(scriptName = "MagicJS", logLevel = "INFO") {
       }
 
       // 自动补完User-Agent，减少请求特征
-      if (!!!_options.headers || typeof _options.headers !== "object" || !!!_options.headers["User-Agent"] || !!!_options.headers["user-agent"]) {
+      if (!!!_options.headers || typeof _options.headers !== "object" || (!!!_options.headers["User-Agent"] && !!!_options.headers["user-agent"])) {
         if (!!!_options.headers || typeof _options.headers !== "object") _options.headers = {};
         if (this.isNode) _options.headers["User-Agent"] = this.pcUserAgent;
         else _options.headers["User-Agent"] = this.iOSUserAgent;

--- a/src/magic.js
+++ b/src/magic.js
@@ -2,7 +2,7 @@ function MagicJS(scriptName = "MagicJS", logLevel = "INFO") {
   return new (class {
     constructor() {
       this._startTime = Date.now();
-      this.version = "2.2.3.6";
+      this.version = "2.2.3.7";
       this.scriptName = scriptName;
       this.logLevels = { DEBUG: 5, INFO: 4, NOTIFY: 3, WARNING: 2, ERROR: 1, CRITICAL: 0, NONE: -1 };
       this.isLoon = typeof $loon !== "undefined";


### PR DESCRIPTION
HTTP协议中，header不区分大小写。
在编写脚本的时候，User-Agent 被写成 user-agent 是一个很正常的行为，例如：https://apps.apple.com/cn/app/id1470567584 的UA就是小写的。
本次修改，在自动补全 UA 的代码段，增加对小写ua的判断，提高脚本的兼容性。